### PR TITLE
modified:   .devcontainer/devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 {
   "name": "Node.js",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24-trixie",
   "features": {
     "ghcr.io/devcontainers-contrib/features/jshint:2": {}
   },


### PR DESCRIPTION
use
image": "mcr.microsoft.com/devcontainers/javascript-node:24-trixie" in
devcontainer/devcontainer.json

Os is updated to Trixie (Debian 13), was Bullseye (Debian 11) Nodejs is updated to 24.13.0 LTS, was 18.20.8
npm is updated to 11.6.2, was 10.8.2