### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/create-blog-from-issue-from-repo.yml
+++ b/.github/workflows/create-blog-from-issue-from-repo.yml
@@ -25,10 +25,13 @@ jobs:
 
       - name: Extract repo name and issue number
         id: vars
+        env:
+          ISSUE_TITLE_INPUT: ${{ github.event.issue.title }}
+          ISSUE_NUMBER_INPUT: ${{ github.event.issue.number }}
         run: |
-          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_TITLE="$ISSUE_TITLE_INPUT"
           REPO_NAME="${ISSUE_TITLE#create blog entry for }"
-          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          ISSUE_NUMBER="$ISSUE_NUMBER_INPUT"
           BRANCH_NAME="feature/${ISSUE_NUMBER}-${REPO_NAME}-create-blog"
           BLOG_FILE="src/content/blog/${REPO_NAME}.md"
           TODAY=$(date +'%B %d %Y')


### PR DESCRIPTION
Potential fix for [https://github.com/roebi/roebi-halter-in-blog/security/code-scanning/1](https://github.com/roebi/roebi-halter-in-blog/security/code-scanning/1)

General fix: stop embedding `${{ ... }}` untrusted expressions directly inside `run:` script bodies. Instead, map them to step environment variables (`env:`), then reference them as `$VAR` in bash.

Best targeted fix here: in `.github/workflows/create-blog-from-issue-from-repo.yml`, update the **“Extract repo name and issue number”** step so:
- `github.event.issue.title` and `github.event.issue.number` are assigned in `env:`.
- `run:` uses `ISSUE_TITLE="$ISSUE_TITLE_INPUT"` and `ISSUE_NUMBER="$ISSUE_NUMBER_INPUT"` (native shell expansion only).
This preserves functionality while removing expression-time injection in shell code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
